### PR TITLE
Move deps into binder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # emacs
 *~
+# installation directory
+deps
+

--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ cd /path/to/local/clone/of/vector-ops
 git checkout -b 10_add_binder
 git push -u origin 10_add_binder
 git submodule add git@github.com:malariagen/binder.git
-echo "deps" >> .gitignore
 git add --all
 git commit -m 'add binder submodule'
 git push

--- a/README.md
+++ b/README.md
@@ -40,7 +40,14 @@ git commit -m 'add pymysql package #10'
 git push
 ```
 
-- Come back here to https://github.com/malariagen/binder and you should now see a "Compare & pull request" button for your new branch. Click this.
+- To test the new environment installs without any errors, you can run locally, e.g.:
+
+```
+cd ..
+./binder/install-conda.sh
+```
+
+- If the local tests look OK and you are ready to propose the changes, come back here to https://github.com/malariagen/binder and you should now see a "Compare & pull request" button for your new branch. Click this.
 - Assuming this issue would be resolved by the pull request, include the text "resolves #10" in the PR description (replacing "10" with whatever is the issue number being resolved). This will mean that when the PR is merged, the corresponding issue will automatically get closed.
 - After PR was created, Travis CI check will automatically run to check that the modified environment can be installed. If any problems arise, these can be traced by clicking 'Details' button next to continuous-integration/travis-ci/pr panel.
 

--- a/env.sh
+++ b/env.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # add miniconda to the path
-export PATH=$(pwd)/deps/conda/bin:$PATH
+export PATH=$(pwd)/binder/deps/conda/bin:$PATH
 
 # add texlive to the path
-export PATH=$(pwd)/deps/texlive/bin/x86_64-linux:$PATH
+export PATH=$(pwd)/binder/deps/texlive/bin/x86_64-linux:$PATH
 
 # determine name of current directory, use as conda environment name
 CONDANAME=${PWD##*/}

--- a/install-conda.sh
+++ b/install-conda.sh
@@ -13,7 +13,7 @@ CONDADIR=conda
 CONDANAME=${PWD##*/}
 
 # descend into dependencies directory
-DEPSDIR=deps
+DEPSDIR=binder/deps
 mkdir -pv $DEPSDIR
 cd $DEPSDIR
 
@@ -61,6 +61,6 @@ fi
 
 echo "[install] installing packages"
 # install packages
-conda env update --name $CONDANAME --file ../binder/environment.yml
+conda env update --name $CONDANAME --file ../environment.yml
 # clean conda caches
 conda clean --yes --all

--- a/install-texlive.sh
+++ b/install-texlive.sh
@@ -9,7 +9,7 @@
 set -xe
 
 # descend into dependencies directory
-DEPSDIR=deps
+DEPSDIR=binder/deps
 mkdir -pv $DEPSDIR
 cd $DEPSDIR
 
@@ -38,7 +38,7 @@ if [ ! -f texlive.installed ]; then
     # run installation
     ./install-tl-*/install-tl \
         -repository=$TEXREPO \
-        -profile=../binder/texlive.profile \
+        -profile=../texlive.profile \
         -no-persistent-downloads \
         -no-verify-downloads
 
@@ -52,6 +52,6 @@ fi
 echo "[install] installing additional texlive packages"
 tlmgr option repository $TEXREPO
 tlmgr_install="tlmgr install --no-persistent-downloads --no-verify-downloads --no-require-verification"
-for package in $(cat ../binder/texlive.packages); do
+for package in $(cat ../texlive.packages); do
     $tlmgr_install $package
 done


### PR DESCRIPTION
This PR moves the "deps" directory down into the "binder" directory. The rationale for doing this is that it makes it easier to do a local test of any changes to the environment, e.g., you can do:

```
cd /path/to/local/clone/of/malariagen/binder
cd ..
./binder/install-conda.sh
```

...and everything will be installed into `/path/to/local/clone/of/malariagen/binder/deps`.

It also means that any parent repo that has malariagen/binder as a submodule does not need to add "deps" to ``.gitignore``.

Resolves #18.

cc @podpearson, @amakunin, @hardingnj 