### PR TITLE
Merge in packages for malariagen/datalab

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+os:
+  - linux
+  - osx
+
 sudo: false
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,4 @@ script:
   - source binder/env.sh
   - conda list
   - python binder/imports.py
+  - pdflatex --version

--- a/env.sh
+++ b/env.sh
@@ -4,7 +4,11 @@
 export PATH=$(pwd)/binder/deps/conda/bin:$PATH
 
 # add texlive to the path
-export PATH=$(pwd)/binder/deps/texlive/bin/x86_64-linux:$PATH
+if [ "$(uname)" == "Darwin" ]; then
+    export PATH=$(pwd)/binder/deps/texlive/bin/x86_64-darwin:$PATH
+elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+    export PATH=$(pwd)/binder/deps/texlive/bin/x86_64-linux:$PATH
+fi
 
 # determine name of current directory, use as conda environment name
 CONDANAME=${PWD##*/}

--- a/environment.yml
+++ b/environment.yml
@@ -42,6 +42,9 @@ dependencies:
   - jupyter=1.0.0
   - jupyter_console=6.0.0
   - jupyter_client=5.2.4
+  # N.B. jupyterhub versions need to match hub image
+  # https://repo2docker.readthedocs.io/en/latest/howto/jupyterhub_images.html
+  - jupyterhub==0.9.4
   - jupyterlab=0.35.4
   - jupyterlab_launcher=0.13.1
   - lmfit=0.9.11
@@ -73,7 +76,7 @@ dependencies:
   - qtconsole=4.4.3
   - s3fs=0.2.0
   - samtools=1.9
-  - scikit-allel=1.1.10
+  - scikit-allel=1.2.0
   - scikit-image=0.14.1
   - scikit-learn=0.19.2
   - scipy=1.1.0
@@ -84,7 +87,6 @@ dependencies:
   - xarray=0.11.0
   - xlrd=1.2.0
   - xlwt=1.3.0
-  - zarr=2.2.0
   - zict=0.1.3
   - pip:
     # version discrepancy for pysam on bioconda, install from pypi to be sure
@@ -111,3 +113,5 @@ dependencies:
     - kubernetes==8.0.0
     - dask-kubernetes==0.6.0
     - nbserverproxy==0.8.8
+    # pre-release zarr, to get consolidated metadata feature
+    - git+https://github.com/zarr-developers/zarr@2c1a6e09f729547d87a9f5b3fb5592706e01e64d

--- a/environment.yml
+++ b/environment.yml
@@ -35,7 +35,8 @@ dependencies:
   - intervaltree=2.1.0
   - ipykernel=5.1.0
   - ipython=7.2.0
-  - ipyleaflet=0.9.2
+  # disable for now, not compatible with xarray 0.11.0
+  # - ipyleaflet=0.9.2
   - ipywidgets=7.4.2
   - joblib=0.13.0
   - jupyter=1.0.0

--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,9 @@ dependencies:
   - cython=0.29.2
   - cytoolz=0.9.0.1
   - dask=1.0.0
-  - dask-ml=0.11.0
+  # disable dask-ml for now, version incompatible with hmmlearn due to 
+  # dependency conflict on scikit-learn
+  # - dask-ml=0.11.0
   - distributed=1.25.1
   - fastcluster=1.1.25
   - fastparquet=0.2.1

--- a/environment.yml
+++ b/environment.yml
@@ -1,38 +1,57 @@
 name: malariagen
 channels:
-  - conda-forge
-  - bioconda
   - defaults
+  - pyviz/label/dev
+  - bokeh/label/dev
+  - intake
+  - bioconda
+  - conda-forge
 dependencies:
   - nomkl
   - python=3.6
   - bcftools=1.9
   - bcolz=1.2.1
   - biopython=1.72
+  - bokeh=1.0.2
+  - bqplot=0.11.2
   - cartopy=0.17.0
   - cython=0.29.2
   - cytoolz=0.9.0.1
   - dask=1.0.0
+  - dask-ml=0.11.0
+  - distributed=1.25.1
   - fastcluster=1.1.25
+  - fastparquet=0.2.1
+  - gcsfs=0.2.0
   - graphviz=2.40.1
   - h5py=2.8.0
   - hmmlearn=0.2.0
+  - holoviews=1.10.9
   - htslib=1.9
   - humanize=0.5.1
+  - intake-xarray=0.2.4
   - intervaltree=2.1.0
   - ipykernel=5.1.0
   - ipython=7.2.0
+  - ipyleaflet=0.9.2
   - ipywidgets=7.4.2
   - joblib=0.13.0
+  - jupyter=1.0.0
   - jupyter_console=6.0.0
+  - jupyter_client=5.2.4
+  - jupyterlab=0.35.4
+  - jupyterlab_launcher=0.13.1
   - lmfit=0.9.11
   - matplotlib=3.0.2
   - matplotlib-venn=0.11.5
+  - msgpack-python=0.6.0
   - msprime=0.6.1
   - mysqlclient=1.3.14
+  - nb_conda_kernels=2.2.0
   - nbconvert=5.4.0
   - nose=1.3.7
   - notebook=5.7.4
+  - numba=0.41.0
   - numcodecs=0.6.2
   - numexpr=2.6.8
   - numpy=1.15.4
@@ -45,18 +64,25 @@ dependencies:
   - pyfasta=0.5.2
   - pyfaidx=0.5.5.2
   - pytables=3.4.4
+  - python-blosc=1.6.2
   - pyvcf=0.6.8
+  - pyzmq=17.1.2
   - qtconsole=4.4.3
+  - s3fs=0.2.0
   - samtools=1.9
   - scikit-allel=1.1.10
+  - scikit-image=0.14.1
   - scikit-learn=0.19.2
   - scipy=1.1.0
   - seaborn=0.9.0
   - snakemake=5.3.1
   - toolz=0.9.0
+  - tornado=5.1.1
+  - xarray=0.11.0
   - xlrd=1.2.0
   - xlwt=1.3.0
   - zarr=2.2.0
+  - zict=0.1.3
   - pip:
     # version discrepancy for pysam on bioconda, install from pypi to be sure
     - pysam==0.15.1
@@ -75,3 +101,10 @@ dependencies:
     - Sphinx==1.8.2
     - sphinx-autobuild==0.7.1
     - sphinx-bootstrap-theme==0.6.5
+    # others from pangeo
+    - fusepy==3.0.1
+    - click==7.0
+    - jedi==0.13.2
+    - kubernetes==8.0.0
+    - dask-kubernetes==0.6.0
+    - nbserverproxy==0.8.8

--- a/install-conda.sh
+++ b/install-conda.sh
@@ -60,6 +60,13 @@ else
 fi
 
 echo "[install] installing packages"
+# ensure channel order - cannot rely on environment.yml
+# https://github.com/conda/conda/issues/7238
+conda config --add channels pyviz/label/dev
+conda config --add channels bokeh/label/dev
+conda config --add channels intake
+conda config --add channels bioconda
+conda config --add channels conda-forge
 # install packages
 conda env update --name $CONDANAME --file ../environment.yml
 # clean conda caches

--- a/install-texlive.sh
+++ b/install-texlive.sh
@@ -14,7 +14,11 @@ mkdir -pv $DEPSDIR
 cd $DEPSDIR
 
 # put dependencies on the path
-export PATH=./texlive/bin/x86_64-linux:$PATH
+if [ "$(uname)" == "Darwin" ]; then
+    export PATH=./texlive/bin/x86_64-darwin:$PATH
+elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+    export PATH=./texlive/bin/x86_64-linux:$PATH
+fi
 
 # use a snapshot mirror to get reproducible install
 #TEXREPO=https://ctanmirror.speedata.de/2017-09-01/systems/texlive/tlnet


### PR DESCRIPTION
This PR adds in packages so that the environment can be used in malariagen datalab.

Also fixes installation of texlive for OSX, and adds OSX to travis CI, which resolves #25.

TODO:
* [x] upgrade scikit-allel to 1.2.0 when it's on conda-forge
* [x] upgrade to pre-release zarr to get consolidated metadata feature