### PR TITLE
Move pysam and pysamstats to conda list #23

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -70,6 +70,8 @@ dependencies:
   - psutil=5.4.8
   - pyfasta=0.5.2
   - pyfaidx=0.5.5.2
+  - pysam=0.15.2
+  - pysamstats=1.1.2
   - pytables=3.4.4
   - python-blosc=1.6.2
   - pyvcf=0.6.8
@@ -90,9 +92,6 @@ dependencies:
   - xlwt=1.3.0
   - zict=0.1.3
   - pip:
-    # version discrepancy for pysam on bioconda, install from pypi to be sure
-    - pysam==0.15.2
-    - pysamstats==1.1.2
     # not on conda-forge
     - anhima==0.11.2
     # not on conda-forge


### PR DESCRIPTION
Closes #23 

@alimanfoo I've moved pysam and pysamstats back from the pip list to the (conda) dependencies, and this now installs fine on both my Mac and on Sanger systems. What was the reason for moving to the pip list (#17)?

Assuming this passes TravisCI, are you happy to pull this in?
