### PR TITLE
Install msprime via pip; upgrade to 0.6.2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -51,7 +51,6 @@ dependencies:
   - matplotlib=3.0.2
   - matplotlib-venn=0.11.5
   - msgpack-python=0.6.0
-  - msprime=0.6.1
   - mysqlclient=1.3.14
   - nb_conda_kernels=2.2.0
   - nbconvert=5.4.0
@@ -98,6 +97,8 @@ dependencies:
     - prettypandas==0.0.4
     # version not on conda-forge
     - graphviz==0.10.1
+    # conda-forge package currently broken on linux
+    - msprime==0.6.2
     # not build for Python 3.6 on conda-forge
     - petlx==1.0.3
     # not on conda-forge


### PR DESCRIPTION
Workaround for #30.