### PR TITLE
Upgrade zarr to 2.3.1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -88,6 +88,7 @@ dependencies:
   - xarray=0.11.3
   - xlrd=1.2.0
   - xlwt=1.3.0
+  - zarr=2.3.1
   - zict=0.1.3
   - pip:
     # not on conda-forge
@@ -111,5 +112,3 @@ dependencies:
     - kubernetes==8.0.1
     - dask-kubernetes==0.7.0
     - nbserverproxy==0.8.8
-    # pre-release zarr, to get consolidated metadata feature
-    - git+https://github.com/zarr-developers/zarr@2c1a6e09f729547d87a9f5b3fb5592706e01e64d


### PR DESCRIPTION
Zarr 2.3.1 has been released, we can upgrade.