### PR TITLE
Express minimum requirements

### DIFF
--- a/install-conda.sh
+++ b/install-conda.sh
@@ -63,11 +63,16 @@ echo "[binder] installing packages"
 echo "[binder] install conda"
 # N.B., pin conda version here, so we don't get any surprises if conda
 # behaviour changes in a future release.
-conda install $CHANNEL_OPTS --yes conda==4.7.11
+conda install $CHANNEL_OPTS --yes conda==4.7.12
 conda --version
 
 echo "[binder] check channel priority - this must be 'true' or 'flexible', ***not*** 'strict'"
 conda config --show channel_priority
+CHANNEL_PRIORITY=$(conda config --show channel_priority)
+if [ "$CHANNEL_PRIORITY" != "channel_priority: flexible" ]; then
+    echo "[binder] channel priority is not flexible, aborting"
+    exit 1
+fi
 
 if [ "$(uname)" == "Darwin" ]; then
     ENVPINNED=${BINDERDIR}/environment-pinned-osx.yml

--- a/requirements-conda.txt
+++ b/requirements-conda.txt
@@ -8,15 +8,15 @@ conda-forge::cartopy
 conda-forge::click
 conda-forge::cython
 conda-forge::cytoolz
-conda-forge::dask
+conda-forge::dask>=2.8.1
 conda-forge::dask-kubernetes
 conda-forge::dask-ml
-conda-forge::distributed
+conda-forge::distributed>=2.8.1
 conda-forge::fastcluster
 conda-forge::fastparquet
-conda-forge::fsspec
+conda-forge::fsspec>=0.6.1
 conda-forge::fusepy
-conda-forge::gcsfs
+conda-forge::gcsfs>=0.5.0
 conda-forge::graphviz
 conda-forge::h5py
 conda-forge::hmmlearn
@@ -54,7 +54,7 @@ conda-forge::numcodecs
 conda-forge::numexpr
 conda-forge::numpy=1.17.3
 conda-forge::openpyxl
-conda-forge::pandas=0.25.3
+conda-forge::pandas>=0.25.3
 conda-forge::peakutils
 conda-forge::petl
 conda-forge::pillow
@@ -67,7 +67,7 @@ conda-forge::python-kubernetes
 conda-forge::pyvcf
 conda-forge::pyzmq
 conda-forge::qtconsole
-conda-forge::s3fs
+conda-forge::s3fs>=0.4.0
 conda-forge::scikit-allel
 conda-forge::scikit-image
 conda-forge::scikit-learn

--- a/variables.sh
+++ b/variables.sh
@@ -1,15 +1,18 @@
 #!/bin/bash
 
+# determine containing directory
+BINDERDIR="$( cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P )"
+
 # determine path to parent repository
 REPODIR="$( cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd -P )"
 
 # determine binder version
-BINDERV=$( cd ${REPODIR}/binder && git rev-parse --short HEAD )
+BINDERV=$( cd ${BINDERDIR} && git rev-parse --short HEAD )
 
 # determine directory in which conda is installed
 if [[ -z "${MALARIAGEN_BINDER_HOME}" ]]; then
     # if not specified by user, default installation location
-    INSTALLDIR=${REPODIR}/binder/deps
+    INSTALLDIR=${BINDERDIR}/deps
 else
     # allow user to specify installation location
     INSTALLDIR=${MALARIAGEN_BINDER_HOME}


### PR DESCRIPTION
This PR makes the following changes:

* In requirements-conda.txt express some minimum version requirements for some packages like dask and distributed, to be sure that the solver never downgrades these.

* Upgrade the version of conda pinned inside install-conda.sh to 4.7.12.

* Exit the install-conda.sh script if channel priority is not what we expect.

* Tidy up some environment variables.

N.B., this is purely maintenance, I am not going to upgrade the pinned environment files in this PR or make a new release.